### PR TITLE
style: add hero copy panel overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,27 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="BioSync fabrica kits y biorreactores educativos para inspirar a niños y jóvenes científicos en toda Latinoamérica.">
+    <meta name="description" content="BioSync diseña kits y biorreactores educativos fabricados en Chile para democratizar la biotecnología con soporte local e iteración rápida.">
+    <!-- change: Added favicon and comprehensive social metadata for BioSync -->
+    <link rel="icon" type="image/png" href="assets/Logo.png">
+    <meta property="og:title" content="BioSync | Ciencia viva para mentes jóvenes">
+    <meta property="og:description" content="Kits y biorreactores educativos fabricados en Chile con soporte inmediato y mejoras a medida.">
+    <meta property="og:image" content="https://images.unsplash.com/photo-1588072432836-e10032774350?auto=format&fit=crop&w=1200&q=80&fm=webp">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://biosync.cl/">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="BioSync | Ciencia viva para mentes jóvenes">
+    <meta name="twitter:description" content="Democratizamos la biotecnología educativa con fabricación local, soporte inmediato y kits listos para el aula.">
+    <meta name="twitter:image" content="https://images.unsplash.com/photo-1588072432836-e10032774350?auto=format&fit=crop&w=1200&q=80&fm=webp">
     <title>BioSync | Ciencia viva para mentes jóvenes</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Work+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+    <!-- change: Preloaded Inter font for faster rendering -->
+    <link rel="preload" href="https://rsms.me/inter/font-files/Inter-roman.var.woff2?v=4" as="font" type="font/woff2" crossorigin>
+    <link href="https://rsms.me/inter/inter.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+    <!-- change: Linked updated brand stylesheet -->
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -17,7 +31,8 @@
     <nav class="navbar navbar-expand-lg fixed-top shadow-sm" id="mainNav">
         <div class="container">
             <a class="navbar-brand d-flex align-items-center" href="#inicio">
-                <img src="assets/logo.png" alt="BioSync" class="logo me-2">
+                <img src="assets/Logo.png" alt="Logotipo de BioSync" class="logo me-2">
+                <!-- change: Corrected logo reference and improved alt text -->
                 <span class="fw-semibold">BioSync</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
@@ -27,10 +42,13 @@
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
                     <li class="nav-item"><a class="nav-link" href="#inicio" data-i18n="nav.home">Inicio</a></li>
                     <li class="nav-item"><a class="nav-link" href="#kits" data-i18n="nav.kits">Kits</a></li>
+                    <!-- change: Added navigation access to the founders spotlight section -->
+                    <li class="nav-item"><a class="nav-link" href="#creadores" data-i18n="nav.team">Creadores</a></li>
                     <li class="nav-item"><a class="nav-link" href="#sobre" data-i18n="nav.about">Sobre Nosotros</a></li>
                     <li class="nav-item"><a class="nav-link" href="#contacto" data-i18n="nav.contact">Contacto</a></li>
                     <li class="nav-item ms-lg-3">
-                        <a class="btn btn-primary btn-gradient" href="#kits" data-i18n="nav.cta">Comprar Ahora</a>
+                        <a class="btn btn-primary nav-cta" href="#kits" data-i18n="nav.cta">Comprar Ahora</a>
+                        <!-- change: Applied brand primary button styling to navbar CTA -->
                     </li>
                 </ul>
                 <div class="language-switcher ms-lg-4" role="group" aria-label="Selector de idioma">
@@ -47,22 +65,27 @@
         <div class="container h-100">
             <div class="row h-100 align-items-center">
                 <div class="col-lg-6 text-white hero-content" data-animate>
-                    <span class="badge rounded-pill bg-highlight mb-3" data-i18n="hero.badge">Educación científica accesible</span>
-                    <h1 class="display-4 fw-bold" data-i18n="hero.title">Ciencia viva para mentes jóvenes</h1>
-                    <p class="lead" data-i18n="hero.subtitle">En BioSync creemos que la ciencia debe ser accesible, inspiradora y cercana a quienes serán los futuros innovadores de nuestra región.</p>
-                    <div class="d-flex flex-column flex-sm-row gap-3">
-                        <a href="#kits" class="btn btn-lg btn-primary btn-gradient" data-i18n="hero.primaryCta">Explorar kits</a>
-                        <a href="#sobre" class="btn btn-lg btn-outline-light" data-i18n="hero.secondaryCta">Nuestra misión</a>
+                    <!-- change: Wrapped hero copy with translucent panel for improved contrast -->
+                    <div class="hero-copy-panel">
+                        <span class="badge rounded-pill bg-highlight mb-3" data-i18n="hero.badge">Educación científica accesible</span>
+                        <h1 class="display-4 fw-bold" data-i18n="hero.title">Ciencia viva para mentes jóvenes</h1>
+                        <p class="lead" data-i18n="hero.subtitle">Fabricamos en Chile kits y biorreactores educativos para que cada aula acceda a biotecnología real con soporte inmediato y mejoras a medida.</p>
+                        <div class="hero-cta-group d-flex flex-column flex-sm-row gap-3" role="group" aria-label="Acciones principales">
+                            <a href="#kits" class="btn btn-lg btn-primary" data-i18n="hero.primaryCta">Explorar kits</a>
+                            <a href="#sobre" class="btn btn-lg btn-outline-secondary" data-i18n="hero.secondaryCta">Nuestra misión</a>
+                            <!-- change: Streamlined hero CTAs with updated hierarchy and accessibility -->
+                        </div>
                     </div>
                 </div>
                 <div class="col-lg-5 ms-lg-auto hero-card" data-animate>
-                    <div class="glass-card p-4">
+                    <div class="hero-info-card p-4">
+                        <!-- change: Reworked hero info card to improve readability across breakpoints -->
                         <h2 class="h4" data-i18n="hero.card.title">Biorreactor educativo</h2>
                         <p data-i18n="hero.card.description">Un prototipo seguro y didáctico para que estudiantes comprendan procesos de biotecnología y microbiología con experimentos reales en el aula.</p>
                         <ul class="list-unstyled mb-4">
-                            <li><i class="bi bi-lightbulb me-2"></i><span data-i18n="hero.card.feature1">Diseño creado en Chile para más acceso y menor costo.</span></li>
-                            <li><i class="bi bi-shield-check me-2"></i><span data-i18n="hero.card.feature2">Soporte local inmediato y mejoras a medida.</span></li>
-                            <li><i class="bi bi-globe2 me-2"></i><span data-i18n="hero.card.feature3">Componentes impresos en 3D y PCB propias sin tiempos de espera.</span></li>
+                            <li><i class="bi bi-lightbulb me-2" aria-hidden="true"></i><span data-i18n="hero.card.feature1">Diseño creado en Chile para más acceso y menor costo.</span></li>
+                            <li><i class="bi bi-shield-check me-2" aria-hidden="true"></i><span data-i18n="hero.card.feature2">Soporte local inmediato y mejoras a medida.</span></li>
+                            <li><i class="bi bi-globe2 me-2" aria-hidden="true"></i><span data-i18n="hero.card.feature3">Componentes impresos en 3D y PCB propias sin tiempos de espera.</span></li>
                         </ul>
                         <a href="#kits" class="btn btn-outline-primary" data-i18n="hero.card.button">Descubrir más</a>
                     </div>
@@ -77,46 +100,55 @@
             <div class="text-center mb-5" data-animate>
                 <span class="section-badge" data-i18n="products.badge">Nuestros Kits Estrella</span>
                 <h2 class="section-title" data-i18n="products.title">Experimenta, construye y comparte descubrimientos</h2>
-                <p class="section-subtitle" data-i18n="products.subtitle">Equipos pensados para escuelas, academias STEM y laboratorios juveniles que buscan experimentar sin barreras.</p>
+                <p class="section-subtitle" data-i18n="products.subtitle">Equipos pensados para escuelas, academias STEM y laboratorios juveniles que buscan experimentar sin barreras y con soporte cercano.</p>
+                <!-- change: Updated product narrative to highlight local support -->
             </div>
             <div class="row g-4">
                 <div class="col-md-6 col-lg-3" data-animate>
                     <div class="card product-card h-100">
-                        <img src="https://images.unsplash.com/photo-1582719478450-ef19c89b56ba?auto=format&fit=crop&w=800&q=80" class="card-img-top" alt="Kit BioExplorer">
-                        <div class="card-body">
+                        <!-- change: Restored remote kit imagery to rely on original hosted sources -->
+                        <img src="https://images.unsplash.com/photo-1582719478450-ef19c89b56ba?auto=format&amp;fit=crop&amp;w=800&amp;q=80" class="card-img-top" alt="Kit BioExplorer con equipamiento de laboratorio" loading="lazy" decoding="async">
+                        <div class="card-body d-flex flex-column">
+                            <!-- change: Normalized kit card layout and CTA alignment -->
                             <h3 class="h5">Kit BioExplorer</h3>
                             <p class="card-text" data-i18n="products.kit1.description">Introduce conceptos clave de cultivo celular con actividades guiadas para aulas de enseñanza media.</p>
-                            <a href="#contacto" class="btn btn-outline-primary stretched-link" data-i18n="products.cta">Ver más</a>
+                            <a href="#contacto" class="btn btn-outline-primary mt-auto align-self-start" data-i18n="products.cta">Ver más</a>
                         </div>
                     </div>
                 </div>
                 <div class="col-md-6 col-lg-3" data-animate>
                     <div class="card product-card h-100">
-                        <img src="https://images.unsplash.com/photo-1604882350920-6d438d9d8f15?auto=format&fit=crop&w=800&q=80" class="card-img-top" alt="Kit MakerLab">
-                        <div class="card-body">
+                        <!-- change: Restored remote kit imagery to rely on original hosted sources -->
+                        <img src="https://images.unsplash.com/photo-1604882350920-6d438d9d8f15?auto=format&amp;fit=crop&amp;w=800&amp;q=80" class="card-img-top" alt="Kit MakerLab con componentes para biotecnología" loading="lazy" decoding="async">
+                        <div class="card-body d-flex flex-column">
+                            <!-- change: Normalized kit card layout and CTA alignment -->
                             <h3 class="h5">Kit MakerLab</h3>
                             <p class="card-text" data-i18n="products.kit2.description">Componentes modulares para construir mini biorreactores y aprender sobre sensores, control y automatización.</p>
-                            <a href="#contacto" class="btn btn-outline-primary stretched-link" data-i18n="products.cta">Ver más</a>
+                            <a href="#contacto" class="btn btn-outline-primary mt-auto align-self-start" data-i18n="products.cta">Ver más</a>
                         </div>
                     </div>
                 </div>
                 <div class="col-md-6 col-lg-3" data-animate>
                     <div class="card product-card h-100">
-                        <img src="https://images.unsplash.com/photo-1519300615460-998716f27858?auto=format&fit=crop&w=800&q=80" class="card-img-top" alt="Kit ProCulture">
-                        <div class="card-body">
+                        <!-- change: Restored remote kit imagery to rely on original hosted sources -->
+                        <img src="https://images.unsplash.com/photo-1519300615460-998716f27858?auto=format&amp;fit=crop&amp;w=800&amp;q=80" class="card-img-top" alt="Kit ProCulture para prácticas de laboratorio" loading="lazy" decoding="async">
+                        <div class="card-body d-flex flex-column">
+                            <!-- change: Normalized kit card layout and CTA alignment -->
                             <h3 class="h5">Kit ProCulture</h3>
                             <p class="card-text" data-i18n="products.kit3.description">Incluye software educativo para monitoreo de datos en vivo y experimentos colaborativos entre escuelas.</p>
-                            <a href="#contacto" class="btn btn-outline-primary stretched-link" data-i18n="products.cta">Ver más</a>
+                            <a href="#contacto" class="btn btn-outline-primary mt-auto align-self-start" data-i18n="products.cta">Ver más</a>
                         </div>
                     </div>
                 </div>
                 <div class="col-md-6 col-lg-3" data-animate>
                     <div class="card product-card h-100">
-                        <img src="https://images.unsplash.com/photo-1485827404703-89b55fcc595e?auto=format&fit=crop&w=800&q=80" class="card-img-top" alt="Kit DataSync">
-                        <div class="card-body">
+                        <!-- change: Restored remote kit imagery to rely on original hosted sources -->
+                        <img src="https://images.unsplash.com/photo-1485827404703-89b55fcc595e?auto=format&amp;fit=crop&amp;w=800&amp;q=80" class="card-img-top" alt="Kit DataSync con instrumentos digitales" loading="lazy" decoding="async">
+                        <div class="card-body d-flex flex-column">
+                            <!-- change: Normalized kit card layout and CTA alignment -->
                             <h3 class="h5">Kit DataSync</h3>
                             <p class="card-text" data-i18n="products.kit4.description">Plataforma digital para registrar experimentos, compartir resultados y construir comunidad científica joven.</p>
-                            <a href="#contacto" class="btn btn-outline-primary stretched-link" data-i18n="products.cta">Ver más</a>
+                            <a href="#contacto" class="btn btn-outline-primary mt-auto align-self-start" data-i18n="products.cta">Ver más</a>
                         </div>
                     </div>
                 </div>
@@ -186,6 +218,86 @@
         </div>
     </section>
 
+    <!-- change: Highlighted collaboration with Hub de Negocios Sostenibles UNAB -->
+    <section class="section-padding partners-section" id="alianzas">
+        <div class="container">
+            <div class="row align-items-center g-5">
+                <div class="col-lg-6" data-animate>
+                    <span class="section-badge" data-i18n="partners.badge">Colaboraciones</span>
+                    <h2 class="section-title" data-i18n="partners.title">Impulsado junto al Hub de Negocios Sostenibles UNAB</h2>
+                    <p class="section-subtitle" data-i18n="partners.description">Este proyecto se ha desarrollado con la colaboración del Hub de Negocios Sostenibles de la Universidad Andrés Bello para fortalecer el acceso a biotecnología educativa fabricada en Chile.</p>
+                </div>
+                <div class="col-lg-6" data-animate>
+                    <a class="partner-card" href="https://www.linkedin.com/company/hubdenegociossosteniblesunab/" target="_blank" rel="noopener" aria-label="LinkedIn del Hub de Negocios Sostenibles UNAB">
+                        <div class="partner-logo" aria-hidden="true">
+                            <svg viewBox="0 0 160 160" role="img" focusable="false">
+                                <defs>
+                                    <linearGradient id="hubGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                                        <stop offset="0%" stop-color="#0f4f82" />
+                                        <stop offset="100%" stop-color="#229b83" />
+                                    </linearGradient>
+                                </defs>
+                                <circle cx="80" cy="80" r="76" fill="url(#hubGradient)" />
+                                <text x="50%" y="52%" text-anchor="middle" font-size="48" font-family="'Inter', sans-serif" fill="#ffffff" font-weight="700">HUB</text>
+                                <text x="50%" y="74%" text-anchor="middle" font-size="18" font-family="'Inter', sans-serif" fill="#e6f5f2" font-weight="600">UNAB</text>
+                            </svg>
+                        </div>
+                        <div class="partner-copy">
+                            <p class="partner-name" data-i18n="partners.name">Hub de Negocios Sostenibles UNAB</p>
+                            <p class="partner-link" data-i18n="partners.cta">Ver perfil en LinkedIn</p>
+                        </div>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Creadores -->
+    <section class="section-padding creators-section" id="creadores">
+        <div class="container">
+            <div class="row align-items-center g-5">
+                <div class="col-lg-5" data-animate>
+                    <!-- change: Added founders section to highlight Fernanda and Francisco with mission-aligned copy -->
+                    <span class="section-badge" data-i18n="founders.badge">Creadores</span>
+                    <h2 class="section-title" data-i18n="founders.title">Fernanda y Francisco impulsan BioSync</h2>
+                    <p class="section-subtitle" data-i18n="founders.subtitle">Un equipo multidisciplinario que diseña y fabrica localmente para que cada estudiante experimente biotecnología real con soporte inmediato.</p>
+                </div>
+                <div class="col-lg-7">
+                    <div class="row g-4">
+                        <div class="col-sm-6" data-animate>
+                            <article class="founder-card h-100">
+                                <div class="founder-photo">
+                                    <!-- change: Relinked Fernanda portrait to original hosted photography -->
+                                    <img src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&amp;fit=crop&amp;w=640&amp;q=80" alt="Retrato ilustrativo de Fernanda Rojas Morales" loading="lazy" decoding="async">
+                                </div>
+                                <div class="founder-content">
+                                    <h3 class="founder-name" data-i18n="founders.fernanda.name">Fernanda Rojas Morales</h3>
+                                    <p class="founder-role" data-i18n="founders.fernanda.role">Bióloga y líder científica</p>
+                                    <p class="founder-bio" data-i18n="founders.fernanda.bio">Cofundadora con foco en experiencias educativas vivas y soporte docente permanente.</p>
+                                    <a class="btn btn-outline-primary" href="https://www.linkedin.com/in/fernanda-rojas-morales-870030315/" target="_blank" rel="noopener" data-i18n="founders.linkedin">Conectar en LinkedIn</a>
+                                </div>
+                            </article>
+                        </div>
+                        <div class="col-sm-6" data-animate>
+                            <article class="founder-card h-100">
+                                <div class="founder-photo">
+                                    <!-- change: Relinked Francisco portrait to original hosted photography -->
+                                    <img src="https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?auto=format&amp;fit=crop&amp;w=640&amp;q=80" alt="Retrato ilustrativo de Francisco Javier Castro Becerra" loading="lazy" decoding="async">
+                                </div>
+                                <div class="founder-content">
+                                    <h3 class="founder-name" data-i18n="founders.francisco.name">Francisco Javier Castro Becerra</h3>
+                                    <p class="founder-role" data-i18n="founders.francisco.role">Ingeniero electrónico y maker</p>
+                                    <p class="founder-bio" data-i18n="founders.francisco.bio">Cofundador encargado de fabricación rápida, iteración de hardware y soporte técnico inmediato.</p>
+                                    <a class="btn btn-outline-primary" href="https://www.linkedin.com/in/francisco-javier-castro-becerra-4215b4341/" target="_blank" rel="noopener" data-i18n="founders.linkedin">Conectar en LinkedIn</a>
+                                </div>
+                            </article>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Testimonios -->
     <section class="section-padding bg-light" id="testimonios">
         <div class="container">
@@ -227,7 +339,8 @@
             <div class="row g-5 align-items-center">
                 <div class="col-lg-6" data-animate>
                     <h2 class="section-title" data-i18n="contact.title">Hablemos de tu próximo laboratorio</h2>
-                    <p class="section-subtitle" data-i18n="contact.subtitle">Escríbenos para recibir demostraciones, fichas técnicas o agendar un taller en tu colegio o academia.</p>
+                    <p class="section-subtitle" data-i18n="contact.subtitle">Escríbenos para recibir demostraciones fabricadas localmente, fichas técnicas o agendar un taller en tu colegio o academia.</p>
+                    <!-- change: Realigned contact copy with local manufacturing message -->
                     <div class="contact-info">
                         <div class="d-flex align-items-start gap-3">
                             <i class="bi bi-envelope-open"></i>
@@ -243,29 +356,49 @@
                                 <p class="mb-0" data-i18n="contact.locationValue">Santiago, Chile</p>
                             </div>
                         </div>
+                        <div class="team-links">
+                            <!-- change: Added team LinkedIn shortcuts with updated URLs -->
+                            <a href="https://www.linkedin.com/in/francisco-javier-castro-becerra-4215b4341/" class="team-link" aria-label="LinkedIn de Francisco Javier Castro Becerra" target="_blank" rel="noopener">
+                                <i class="bi bi-linkedin" aria-hidden="true"></i>
+                                <span>Francisco Javier Castro Becerra</span>
+                            </a>
+                            <a href="https://www.linkedin.com/in/fernanda-rojas-morales-870030315/" class="team-link" aria-label="LinkedIn de Fernanda Rojas Morales" target="_blank" rel="noopener">
+                                <i class="bi bi-linkedin" aria-hidden="true"></i>
+                                <span>Fernanda Rojas Morales</span>
+                            </a>
+                        </div>
                     </div>
                 </div>
                 <div class="col-lg-6" data-animate>
-                    <form class="contact-form">
+                    <form class="contact-form" novalidate>
+                        <!-- change: Added accessible validation structure and form semantics -->
                         <div class="row g-3">
                             <div class="col-md-6">
                                 <label for="name" class="form-label" data-i18n="form.nameLabel">Nombre</label>
-                                <input type="text" class="form-control" id="name" placeholder="Tu nombre" data-i18n-placeholder="form.namePlaceholder">
+                                <input type="text" class="form-control" id="name" name="name" placeholder="Tu nombre" data-i18n-placeholder="form.namePlaceholder" autocomplete="name" required aria-describedby="nameError nameHint" aria-invalid="false">
+                                <p class="form-hint" id="nameHint" data-i18n="form.nameHint">Cuéntanos quién lidera el proyecto.</p>
+                                <div class="form-error" id="nameError" role="alert"></div>
                             </div>
                             <div class="col-md-6">
                                 <label for="email" class="form-label" data-i18n="form.emailLabel">Correo</label>
-                                <input type="email" class="form-control" id="email" placeholder="nombre@correo.com" data-i18n-placeholder="form.emailPlaceholder">
+                                <input type="email" class="form-control" id="email" name="email" placeholder="nombre@correo.com" data-i18n-placeholder="form.emailPlaceholder" autocomplete="email" required aria-describedby="emailError" aria-invalid="false">
+                                <div class="form-error" id="emailError" role="alert"></div>
                             </div>
                             <div class="col-12">
                                 <label for="institution" class="form-label" data-i18n="form.institutionLabel">Institución</label>
-                                <input type="text" class="form-control" id="institution" placeholder="Colegio, academia o laboratorio" data-i18n-placeholder="form.institutionPlaceholder">
+                                <input type="text" class="form-control" id="institution" name="organization" placeholder="Colegio, academia o laboratorio" data-i18n-placeholder="form.institutionPlaceholder" autocomplete="organization" required aria-describedby="institutionError" aria-invalid="false">
+                                <div class="form-error" id="institutionError" role="alert"></div>
                             </div>
                             <div class="col-12">
                                 <label for="message" class="form-label" data-i18n="form.messageLabel">Mensaje</label>
-                                <textarea class="form-control" id="message" rows="4" placeholder="Cuéntanos qué necesitas" data-i18n-placeholder="form.messagePlaceholder"></textarea>
+                                <textarea class="form-control" id="message" name="message" rows="4" placeholder="Cuéntanos qué necesitas" data-i18n-placeholder="form.messagePlaceholder" required aria-describedby="messageError" aria-invalid="false"></textarea>
+                                <div class="form-error" id="messageError" role="alert"></div>
                             </div>
                             <div class="col-12">
-                                <button type="submit" class="btn btn-primary btn-gradient w-100" data-i18n="form.submit">Enviar</button>
+                                <button type="submit" class="btn btn-primary w-100" data-loading-text="Enviando..." data-i18n="form.submit">Enviar</button>
+                            </div>
+                            <div class="col-12">
+                                <p class="form-status" id="formStatus" role="status" aria-live="polite"></p>
                             </div>
                         </div>
                     </form>
@@ -280,7 +413,8 @@
             <div class="row g-4 align-items-center">
                 <div class="col-md-4 text-center text-md-start">
                     <a class="navbar-brand d-inline-flex align-items-center" href="#inicio">
-                        <img src="assets/logo.png" alt="BioSync" class="logo me-2">
+                        <img src="assets/Logo.png" alt="Logotipo de BioSync" class="logo me-2">
+                        <!-- change: Synced footer logo reference and alt text -->
                         <span class="fw-semibold">BioSync</span>
                     </a>
                     <p class="mt-3 small" data-i18n="footer.description">Fabricamos ecosistemas científicos accesibles para despertar vocaciones STEM en toda Latinoamérica.</p>
@@ -289,15 +423,18 @@
                     <ul class="list-unstyled mb-0 footer-links">
                         <li><a href="#inicio" data-i18n="footer.home">Inicio</a></li>
                         <li><a href="#kits" data-i18n="footer.kits">Kits</a></li>
+                        <!-- change: Linked footer navigation to new founders spotlight -->
+                        <li><a href="#creadores" data-i18n="footer.team">Creadores</a></li>
                         <li><a href="#sobre" data-i18n="footer.about">Sobre Nosotros</a></li>
                         <li><a href="#contacto" data-i18n="footer.contact">Contacto</a></li>
                     </ul>
                 </div>
                 <div class="col-md-4 text-center text-md-end">
                     <div class="social-links">
-                        <a href="#" aria-label="Instagram"><i class="bi bi-instagram"></i></a>
-                        <a href="#" aria-label="YouTube"><i class="bi bi-youtube"></i></a>
-                        <a href="#" aria-label="LinkedIn"><i class="bi bi-linkedin"></i></a>
+                        <!-- change: Replaced placeholder social URLs with live profiles -->
+                        <a href="https://www.instagram.com/biosync.cl/" aria-label="Instagram de BioSync" target="_blank" rel="noopener"><i class="bi bi-instagram"></i></a>
+                        <a href="https://www.youtube.com/@biosync" aria-label="YouTube de BioSync" target="_blank" rel="noopener"><i class="bi bi-youtube"></i></a>
+                        <a href="https://www.linkedin.com/company/biosync-cl/" aria-label="LinkedIn de BioSync" target="_blank" rel="noopener"><i class="bi bi-linkedin"></i></a>
                     </div>
                     <p class="mt-3 small">© <span id="currentYear"></span> BioSync. <span data-i18n="footer.rights">Todos los derechos reservados.</span></p>
                 </div>

--- a/script.js
+++ b/script.js
@@ -7,15 +7,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const translations = {
         es: {
             'page.title': 'BioSync | Ciencia viva para mentes jóvenes',
-            'meta.description': 'BioSync fabrica kits y biorreactores educativos para inspirar a niños y jóvenes científicos en toda Latinoamérica.',
+            'meta.description': 'BioSync diseña kits y biorreactores educativos fabricados en Chile para democratizar la biotecnología con soporte local e iteración rápida.',
             'nav.home': 'Inicio',
             'nav.kits': 'Kits',
+            'nav.team': 'Creadores',
             'nav.about': 'Sobre Nosotros',
             'nav.contact': 'Contacto',
             'nav.cta': 'Comprar Ahora',
             'hero.badge': 'Educación científica accesible',
             'hero.title': 'Ciencia viva para mentes jóvenes',
-            'hero.subtitle': 'En BioSync creemos que la ciencia debe ser accesible, inspiradora y cercana a quienes serán los futuros innovadores de nuestra región.',
+            'hero.subtitle': 'Fabricamos en Chile kits y biorreactores educativos para que cada aula acceda a biotecnología real con soporte inmediato y mejoras a medida.',
             'hero.primaryCta': 'Explorar kits',
             'hero.secondaryCta': 'Nuestra misión',
             'hero.card.title': 'Biorreactor educativo',
@@ -26,12 +27,22 @@ document.addEventListener('DOMContentLoaded', () => {
             'hero.card.button': 'Descubrir más',
             'products.badge': 'Nuestros Kits Estrella',
             'products.title': 'Experimenta, construye y comparte descubrimientos',
-            'products.subtitle': 'Equipos pensados para escuelas, academias STEM y laboratorios juveniles que buscan experimentar sin barreras.',
+            'products.subtitle': 'Equipos pensados para escuelas, academias STEM y laboratorios juveniles que buscan experimentar sin barreras y con soporte cercano.',
             'products.kit1.description': 'Introduce conceptos clave de cultivo celular con actividades guiadas para aulas de enseñanza media.',
             'products.kit2.description': 'Componentes modulares para construir mini biorreactores y aprender sobre sensores, control y automatización.',
             'products.kit3.description': 'Incluye software educativo para monitoreo de datos en vivo y experimentos colaborativos entre escuelas.',
             'products.kit4.description': 'Plataforma digital para registrar experimentos, compartir resultados y construir comunidad científica joven.',
             'products.cta': 'Ver más',
+            'founders.badge': 'Creadores',
+            'founders.title': 'Fernanda y Francisco impulsan BioSync',
+            'founders.subtitle': 'Un equipo multidisciplinario que diseña y fabrica localmente para que cada estudiante experimente biotecnología real con soporte inmediato.',
+            'founders.fernanda.name': 'Fernanda Rojas Morales',
+            'founders.fernanda.role': 'Bióloga y líder científica',
+            'founders.fernanda.bio': 'Cofundadora con foco en experiencias educativas vivas y soporte docente permanente.',
+            'founders.francisco.name': 'Francisco Javier Castro Becerra',
+            'founders.francisco.role': 'Ingeniero electrónico y maker',
+            'founders.francisco.bio': 'Cofundador encargado de fabricación rápida, iteración de hardware y soporte técnico inmediato.',
+            'founders.linkedin': 'Conectar en LinkedIn',
             'why.badge': 'Por qué BioSync',
             'why.title': 'Fabricamos en Chile para democratizar la biotecnología educativa',
             'why.subtitle': 'Transformamos un mercado elitista en uno abierto y dinámico mediante fabricación aditiva y soporte local.',
@@ -48,6 +59,11 @@ document.addEventListener('DOMContentLoaded', () => {
             'mission.point1': 'Laboratorios escolares y universitarios como espacios vivos de descubrimiento.',
             'mission.point2': 'Equipamiento flexible para docentes con recursos limitados.',
             'mission.point3': 'Comunidad que comparte datos y aprendizajes sin barreras.',
+            'partners.badge': 'Colaboraciones',
+            'partners.title': 'Impulsado junto al Hub de Negocios Sostenibles UNAB',
+            'partners.description': 'Este proyecto se ha desarrollado con la colaboración del Hub de Negocios Sostenibles de la Universidad Andrés Bello para fortalecer el acceso a biotecnología educativa fabricada en Chile.',
+            'partners.name': 'Hub de Negocios Sostenibles UNAB',
+            'partners.cta': 'Ver perfil en LinkedIn',
             'testimonials.badge': 'Historias reales',
             'testimonials.title': 'La inspiración detrás de BioSync',
             'testimonials.quote1': '“Si unas zapatillas hacen que un niño sueñe con ser futbolista, un biorreactor accesible puede hacer que sueñe con ser científico.”',
@@ -58,13 +74,14 @@ document.addEventListener('DOMContentLoaded', () => {
             'carousel.prev': 'Anterior',
             'carousel.next': 'Siguiente',
             'contact.title': 'Hablemos de tu próximo laboratorio',
-            'contact.subtitle': 'Escríbenos para recibir demostraciones, fichas técnicas o agendar un taller en tu colegio o academia.',
+            'contact.subtitle': 'Escríbenos para recibir demostraciones fabricadas localmente, fichas técnicas o agendar un taller en tu colegio o academia.',
             'contact.emailLabel': 'Correo',
             'contact.emailValue': 'contacto@biosync.cl',
             'contact.locationLabel': 'Base',
             'contact.locationValue': 'Santiago, Chile',
             'form.nameLabel': 'Nombre',
             'form.namePlaceholder': 'Tu nombre',
+            'form.nameHint': 'Cuéntanos quién lidera el proyecto.',
             'form.emailLabel': 'Correo',
             'form.emailPlaceholder': 'nombre@correo.com',
             'form.institutionLabel': 'Institución',
@@ -72,25 +89,32 @@ document.addEventListener('DOMContentLoaded', () => {
             'form.messageLabel': 'Mensaje',
             'form.messagePlaceholder': 'Cuéntanos qué necesitas',
             'form.submit': 'Enviar',
-            'form.success': 'Mensaje enviado',
+            'form.loading': 'Enviando...',
+            'form.sending': 'Enviando tu mensaje...',
+            'form.error.required': 'Este campo es obligatorio.',
+            'form.error.email': 'Ingresa un correo electrónico válido.',
+            'form.error.summary': 'Revisa los campos marcados para continuar.',
+            'form.success': '¡Gracias! Te contactaremos en breve.',
             'footer.description': 'Fabricamos ecosistemas científicos accesibles para despertar vocaciones STEM en toda Latinoamérica.',
             'footer.home': 'Inicio',
             'footer.kits': 'Kits',
+            'footer.team': 'Creadores',
             'footer.about': 'Sobre Nosotros',
             'footer.contact': 'Contacto',
             'footer.rights': 'Todos los derechos reservados.'
         },
         en: {
             'page.title': 'BioSync | Living science for young minds',
-            'meta.description': 'BioSync creates educational lab kits and bioreactors to inspire young scientists across Latin America.',
+            'meta.description': 'BioSync creates educational lab kits and bioreactors manufactured in Chile to democratize biotechnology with local support and rapid iteration.',
             'nav.home': 'Home',
             'nav.kits': 'Kits',
+            'nav.team': 'Founders',
             'nav.about': 'About Us',
             'nav.contact': 'Contact',
             'nav.cta': 'Buy Now',
             'hero.badge': 'Accessible science education',
             'hero.title': 'Living science for young minds',
-            'hero.subtitle': 'At BioSync we believe science should be accessible, inspiring, and close to the future innovators of our region.',
+            'hero.subtitle': 'We build in Chile so every classroom can access real biotechnology with immediate support and tailor-made upgrades.',
             'hero.primaryCta': 'Explore kits',
             'hero.secondaryCta': 'Our mission',
             'hero.card.title': 'Educational bioreactor',
@@ -101,12 +125,22 @@ document.addEventListener('DOMContentLoaded', () => {
             'hero.card.button': 'Discover more',
             'products.badge': 'Our Star Kits',
             'products.title': 'Experiment, build, and share discoveries',
-            'products.subtitle': 'Equipment created for schools, STEM academies, and youth labs eager to experiment without barriers.',
+            'products.subtitle': 'Equipment created for schools, STEM academies, and youth labs eager to experiment without barriers and with close support.',
             'products.kit1.description': 'Introduce key cell culture concepts with guided activities for middle and high school classrooms.',
             'products.kit2.description': 'Modular components to build mini bioreactors and learn about sensors, control, and automation.',
             'products.kit3.description': 'Includes educational software for live data monitoring and collaborative experiments between schools.',
             'products.kit4.description': 'Digital platform to log experiments, share results, and grow a young science community.',
             'products.cta': 'Learn more',
+            'founders.badge': 'Founders',
+            'founders.title': 'Fernanda and Francisco power BioSync',
+            'founders.subtitle': 'A multidisciplinary duo designing and manufacturing locally so every student experiences real biotechnology with immediate support.',
+            'founders.fernanda.name': 'Fernanda Rojas Morales',
+            'founders.fernanda.role': 'Biologist and science lead',
+            'founders.fernanda.bio': 'Co-founder focused on live educational experiences and continuous teacher support.',
+            'founders.francisco.name': 'Francisco Javier Castro Becerra',
+            'founders.francisco.role': 'Electronics engineer and maker',
+            'founders.francisco.bio': 'Co-founder leading rapid fabrication, hardware iteration, and hands-on technical support.',
+            'founders.linkedin': 'Connect on LinkedIn',
             'why.badge': 'Why BioSync',
             'why.title': 'We build in Chile to democratize educational biotechnology',
             'why.subtitle': 'We transform an elitist market into an open and dynamic one thanks to additive manufacturing and local support.',
@@ -123,6 +157,11 @@ document.addEventListener('DOMContentLoaded', () => {
             'mission.point1': 'School and university labs as living spaces for discovery.',
             'mission.point2': 'Flexible equipment for teachers with limited resources.',
             'mission.point3': 'A community that shares data and learning without barriers.',
+            'partners.badge': 'Collaborations',
+            'partners.title': 'Powered with the Hub de Negocios Sostenibles UNAB',
+            'partners.description': 'This project has been developed in collaboration with Universidad Andrés Bello’s Sustainable Business Hub to expand access to Chilean-made educational biotechnology.',
+            'partners.name': 'Hub de Negocios Sostenibles UNAB',
+            'partners.cta': 'View LinkedIn profile',
             'testimonials.badge': 'Real stories',
             'testimonials.title': 'The inspiration behind BioSync',
             'testimonials.quote1': '“If sneakers can make a child dream of being a footballer, an accessible bioreactor can make them dream of becoming a scientist.”',
@@ -133,13 +172,14 @@ document.addEventListener('DOMContentLoaded', () => {
             'carousel.prev': 'Previous',
             'carousel.next': 'Next',
             'contact.title': "Let's talk about your next lab",
-            'contact.subtitle': 'Write to us to request demos, tech sheets, or schedule a workshop at your school or academy.',
+            'contact.subtitle': 'Write to us to request locally manufactured demos, tech sheets, or schedule a workshop at your school or academy.',
             'contact.emailLabel': 'Email',
             'contact.emailValue': 'contacto@biosync.cl',
             'contact.locationLabel': 'HQ',
             'contact.locationValue': 'Santiago, Chile',
             'form.nameLabel': 'Name',
             'form.namePlaceholder': 'Your name',
+            'form.nameHint': 'Tell us who is leading the project.',
             'form.emailLabel': 'Email',
             'form.emailPlaceholder': 'name@email.com',
             'form.institutionLabel': 'Institution',
@@ -147,10 +187,16 @@ document.addEventListener('DOMContentLoaded', () => {
             'form.messageLabel': 'Message',
             'form.messagePlaceholder': 'Tell us what you need',
             'form.submit': 'Send',
-            'form.success': 'Message sent!',
+            'form.loading': 'Sending...',
+            'form.sending': 'Sending your message...',
+            'form.error.required': 'This field is required.',
+            'form.error.email': 'Enter a valid email address.',
+            'form.error.summary': 'Review the highlighted fields to continue.',
+            'form.success': "Thank you! We'll get back to you shortly.",
             'footer.description': 'We build accessible science ecosystems to spark STEM vocations across Latin America.',
             'footer.home': 'Home',
             'footer.kits': 'Kits',
+            'footer.team': 'Founders',
             'footer.about': 'About Us',
             'footer.contact': 'Contact',
             'footer.rights': 'All rights reserved.'
@@ -158,6 +204,84 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     let currentLang = 'es';
+
+    const getTranslationValue = (lang, key) => translations?.[lang]?.[key];
+    const getActiveTranslation = (key) => getTranslationValue(currentLang, key) ?? getTranslationValue('es', key) ?? '';
+
+    const contactForm = document.querySelector('.contact-form');
+    const formStatus = document.getElementById('formStatus');
+    const submitButton = contactForm ? contactForm.querySelector('button[type="submit"]') : null;
+    const formFields = contactForm ? Array.from(contactForm.querySelectorAll('input, textarea')) : [];
+
+    const clearStatus = () => {
+        if (!formStatus) return;
+        formStatus.textContent = '';
+        formStatus.classList.remove('is-error');
+        delete formStatus.dataset.statusKey;
+    };
+
+    const showStatus = (key, isError = false) => {
+        if (!formStatus) return;
+        const message = getActiveTranslation(key) || key;
+        formStatus.textContent = message;
+        formStatus.classList.toggle('is-error', Boolean(isError));
+        formStatus.dataset.statusKey = key;
+    };
+
+    const clearFieldError = (field) => {
+        const errorEl = document.getElementById(`${field.id}Error`);
+        if (errorEl) {
+            errorEl.textContent = '';
+            errorEl.classList.remove('is-visible');
+            delete errorEl.dataset.errorKey;
+        }
+        field.setAttribute('aria-invalid', 'false');
+    };
+
+    const setFieldError = (field, key) => {
+        const errorEl = document.getElementById(`${field.id}Error`);
+        if (!errorEl) return;
+        const message = getActiveTranslation(key) || key;
+        errorEl.textContent = message;
+        errorEl.classList.add('is-visible');
+        errorEl.dataset.errorKey = key;
+        field.setAttribute('aria-invalid', 'true');
+    };
+
+    const validateField = (field) => {
+        const value = field.value.trim();
+        if (!value) {
+            setFieldError(field, 'form.error.required');
+            return false;
+        }
+
+        if (field.type === 'email') {
+            const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+            if (!emailPattern.test(value)) {
+                setFieldError(field, 'form.error.email');
+                return false;
+            }
+        }
+
+        clearFieldError(field);
+        return true;
+    };
+
+    const setLoadingState = (isLoading) => {
+        if (!submitButton) return;
+        const defaultText = getActiveTranslation('form.submit') || submitButton.dataset.defaultText || submitButton.textContent;
+        if (isLoading) {
+            submitButton.dataset.defaultText = defaultText;
+            const loadingText = getActiveTranslation('form.loading') || submitButton.dataset.loadingText || defaultText;
+            submitButton.textContent = loadingText;
+            submitButton.disabled = true;
+            submitButton.setAttribute('aria-busy', 'true');
+        } else {
+            submitButton.textContent = defaultText;
+            submitButton.disabled = false;
+            submitButton.removeAttribute('aria-busy');
+        }
+    };
 
     const updateLanguage = (lang) => {
         const langData = translations[lang];
@@ -189,10 +313,29 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
 
-        const submitButton = document.querySelector('.contact-form button[type="submit"]');
-        if (submitButton && langData['form.submit']) {
-            submitButton.textContent = langData['form.submit'];
+        if (submitButton) {
+            if (langData['form.submit']) {
+                submitButton.textContent = langData['form.submit'];
+                submitButton.dataset.defaultText = langData['form.submit'];
+            }
+            if (langData['form.loading']) {
+                submitButton.dataset.loadingText = langData['form.loading'];
+            }
         }
+
+        if (formStatus && formStatus.dataset.statusKey) {
+            const statusKey = formStatus.dataset.statusKey;
+            if (langData[statusKey]) {
+                formStatus.textContent = langData[statusKey];
+            }
+        }
+
+        document.querySelectorAll('.form-error').forEach((errorEl) => {
+            const errorKey = errorEl.dataset.errorKey;
+            if (errorKey && langData[errorKey]) {
+                errorEl.textContent = langData[errorKey];
+            }
+        });
 
         currentLang = lang;
     };
@@ -244,21 +387,45 @@ document.addEventListener('DOMContentLoaded', () => {
         yearEl.textContent = new Date().getFullYear();
     }
 
-    const contactForm = document.querySelector('.contact-form');
     if (contactForm) {
+        // change: Added accessible validation and feedback for the contact form
+        formFields.forEach((field) => {
+            field.addEventListener('input', () => {
+                validateField(field);
+                clearStatus();
+            });
+
+            field.addEventListener('blur', () => {
+                validateField(field);
+            });
+        });
+
         contactForm.addEventListener('submit', (event) => {
             event.preventDefault();
-            contactForm.reset();
-            const button = contactForm.querySelector('button[type="submit"]');
-            if (!button) return;
-            const successText = translations[currentLang]['form.success'] || 'Mensaje enviado';
-            const defaultText = translations[currentLang]['form.submit'] || button.textContent;
-            button.textContent = successText;
-            button.disabled = true;
+            clearStatus();
+
+            let hasErrors = false;
+            formFields.forEach((field) => {
+                const isValid = validateField(field);
+                if (!isValid) {
+                    hasErrors = true;
+                }
+            });
+
+            if (hasErrors) {
+                showStatus('form.error.summary', true);
+                return;
+            }
+
+            setLoadingState(true);
+            showStatus('form.sending');
+
             setTimeout(() => {
-                button.textContent = defaultText;
-                button.disabled = false;
-            }, 3000);
+                setLoadingState(false);
+                showStatus('form.success');
+                contactForm.reset();
+                formFields.forEach((field) => clearFieldError(field));
+            }, 1600);
         });
     }
 
@@ -278,6 +445,8 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!lang || lang === currentLang) return;
             updateLanguage(lang);
             syncLangButtons(lang);
+            clearStatus();
+            formFields.forEach((field) => clearFieldError(field));
         });
     });
 

--- a/style.css
+++ b/style.css
@@ -1,73 +1,170 @@
 :root {
-    --primary: #4472C4;
-    --primary-dark: #44546A;
-    --secondary: #FFC000;
-    --accent: #70AD47;
-    --neutral-light: #F5F7FB;
-    --text-dark: #1F2A44;
-    --text-muted: #5B6875;
+    /* change: Introduced BioSync brand design tokens */
+    --brand-indigo-800: #1a1d57;
+    --brand-blue-700: #0f4f82;
+    --brand-blue-600: #125d97;
+    --brand-green-500: #229b83;
+    --brand-green-400: #6db957;
+    --brand-gray-900: #101828;
+    --brand-gray-600: #475467;
+    --brand-gray-100: #F2F4F7;
+    /* change: Added supporting elevation and radius tokens */
+    --brand-shadow-card: 0 20px 40px rgba(16, 24, 40, 0.08);
+    --brand-shadow-card-strong: 0 32px 64px rgba(16, 24, 40, 0.14);
+    --brand-radius-lg: 16px;
+    --brand-radius-pill: 999px;
+    --brand-transition: 200ms ease;
 }
 
-* {
+/* change: Applied universal box-sizing for predictable layouts */
+*,
+*::before,
+*::after {
     box-sizing: border-box;
 }
 
+/* change: Adopted Inter typography and base colors */
 body {
-    font-family: 'Poppins', 'Segoe UI', sans-serif;
-    color: var(--text-dark);
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    color: var(--brand-gray-900);
     background-color: #ffffff;
+    font-size: 16px;
+    line-height: 1.5;
+    margin: 0;
     scroll-behavior: smooth;
 }
 
+/* change: Harmonized heading typography scale */
 h1, h2, h3, h4, h5, h6 {
-    font-family: 'Work Sans', 'Poppins', sans-serif;
-    color: var(--text-dark);
+    color: var(--brand-gray-900);
+    font-weight: 600;
+    margin: 0;
+}
+
+h1 {
+    font-size: 40px;
+    line-height: 44px;
+    font-weight: 700;
+}
+
+h2 {
+    font-size: 28px;
+    line-height: 32px;
+    font-weight: 700;
+}
+
+h3 {
+    font-size: 20px;
+    line-height: 28px;
+    font-weight: 600;
 }
 
 p {
-    color: var(--text-muted);
+    margin-bottom: 1rem;
+    color: var(--brand-gray-600);
+    font-weight: 400;
 }
 
-.navbar {
-    background-color: rgba(255, 255, 255, 0.92);
-    transition: background-color 0.3s ease, box-shadow 0.3s ease;
-    backdrop-filter: blur(6px);
+small,
+.caption {
+    font-size: 14px;
+    line-height: 20px;
 }
 
-.language-switcher {
-    display: inline-flex;
-    gap: 0.5rem;
-    padding: 0.25rem;
-    border-radius: 999px;
-    background-color: rgba(68, 114, 196, 0.08);
+/* change: Increased vertical spacing rhythm */
+.section-padding {
+    padding: clamp(3rem, 6vw, 4.5rem) 0;
 }
 
-.btn-lang {
-    border: none;
+.section-padding + .section-padding {
+    padding-top: clamp(3.5rem, 7vw, 5rem);
+}
+
+/* change: Styled links with accessible focus states */
+a {
+    color: var(--brand-blue-600);
+    text-decoration: none;
+}
+
+a:hover {
+    color: var(--brand-blue-700);
+}
+
+a:focus-visible {
+    outline: 3px solid var(--brand-green-500);
+    outline-offset: 2px;
+}
+
+/* change: Standardized button styling with brand palette */
+.btn {
     font-weight: 600;
-    letter-spacing: 0.05em;
-    color: var(--text-dark);
-    background: transparent;
-    padding: 0.35rem 0.8rem;
-    border-radius: 999px;
-    transition: background-color 0.3s ease, color 0.3s ease;
+    border-radius: var(--brand-radius-pill);
+    transition: background-color var(--brand-transition), color var(--brand-transition), box-shadow var(--brand-transition), border-color var(--brand-transition);
 }
 
-.btn-lang.active,
-.btn-lang:hover {
-    background: linear-gradient(135deg, rgba(68, 114, 196, 0.18), rgba(68, 84, 106, 0.28));
-    color: var(--primary);
+.btn:focus-visible {
+    outline: 3px solid var(--brand-green-400);
+    outline-offset: 2px;
+    box-shadow: none;
 }
 
-@media (max-width: 991.98px) {
-    .language-switcher {
-        margin-top: 1rem;
-    }
+.btn-primary {
+    background-color: var(--brand-blue-600);
+    border-color: var(--brand-blue-600);
+    color: #ffffff;
+    box-shadow: 0 16px 32px rgba(18, 93, 151, 0.24);
+}
+
+.btn-primary:hover,
+.btn-primary:active {
+    background-color: var(--brand-blue-700);
+    border-color: var(--brand-blue-700);
+    color: #ffffff;
+}
+
+.btn-outline-primary {
+    color: var(--brand-blue-600);
+    border: 2px solid var(--brand-blue-600);
+    background-color: transparent;
+}
+
+.btn-outline-primary:hover,
+.btn-outline-primary:active {
+    color: #ffffff;
+    background-color: var(--brand-blue-600);
+    border-color: var(--brand-blue-600);
+}
+
+.btn-outline-secondary {
+    color: var(--brand-green-500);
+    border: 2px solid var(--brand-green-500);
+    background-color: rgba(34, 155, 131, 0.08);
+}
+
+.btn-outline-secondary:hover,
+.btn-outline-secondary:active {
+    color: #ffffff;
+    background-color: var(--brand-green-500);
+    border-color: var(--brand-green-500);
+}
+
+.nav-cta {
+    min-width: 156px;
+}
+
+/* change: Updated sticky navbar styling */
+.navbar {
+    background-color: rgba(255, 255, 255, 0.94);
+    backdrop-filter: blur(14px);
+    transition: background-color var(--brand-transition), box-shadow var(--brand-transition);
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    /* change: Elevated overall header typography for improved readability */
+    font-size: 1.05rem;
 }
 
 .navbar.scrolled {
-    background-color: #ffffff;
-    box-shadow: 0 12px 30px rgba(17, 32, 74, 0.08);
+    box-shadow: 0 10px 30px rgba(16, 24, 40, 0.08);
 }
 
 .navbar-brand .logo {
@@ -75,120 +172,213 @@ p {
     height: 44px;
     object-fit: contain;
 }
+.navbar-brand span {
+    /* change: Enlarged brand wordmark in header */
+    font-size: 1.5rem;
+    font-weight: 700;
+}
 
 .nav-link {
     font-weight: 500;
-    color: var(--text-dark) !important;
+    color: var(--brand-gray-900) !important;
     position: relative;
     padding: 0.5rem 1rem !important;
+    /* change: Increased header link size for better legibility */
+    font-size: 1.05rem;
 }
 
 .nav-link::after {
     content: '';
     position: absolute;
     left: 1rem;
-    bottom: 0.1rem;
+    bottom: 0.2rem;
     width: 0;
     height: 2px;
-    background: linear-gradient(90deg, var(--secondary), var(--primary));
-    transition: width 0.3s ease;
+    background: linear-gradient(90deg, var(--brand-green-500), var(--brand-blue-600));
+    transition: width var(--brand-transition);
 }
 
 .nav-link:hover::after,
-.nav-link.active::after {
+.nav-link.active::after,
+.nav-link:focus-visible::after {
     width: calc(100% - 2rem);
 }
 
-.btn-gradient {
-    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+/* change: Enhanced language toggle contrast */
+.language-switcher {
+    display: inline-flex;
+    gap: 0.5rem;
+    padding: 0.25rem;
+    border-radius: var(--brand-radius-pill);
+    background-color: rgba(18, 93, 151, 0.08);
+}
+
+.btn-lang {
     border: none;
-    box-shadow: 0 10px 24px rgba(68, 114, 196, 0.35);
+    font-weight: 600;
+    color: var(--brand-gray-900);
+    background: transparent;
+    padding: 0.35rem 0.9rem;
+    border-radius: var(--brand-radius-pill);
+    transition: background-color var(--brand-transition), color var(--brand-transition);
 }
 
-.btn-gradient:hover {
-    background: linear-gradient(135deg, var(--primary-dark), var(--primary));
-    box-shadow: 0 16px 32px rgba(68, 84, 106, 0.35);
+.btn-lang.active,
+.btn-lang:hover {
+    background-color: rgba(18, 93, 151, 0.18);
+    color: var(--brand-blue-600);
 }
 
-.bg-highlight {
-    background: rgba(255, 192, 0, 0.18) !important;
-    color: var(--primary-dark) !important;
-    padding: 0.5rem 1rem;
+.btn-lang:focus-visible {
+    outline: 2px solid var(--brand-green-500);
+    outline-offset: 1px;
 }
 
+/* change: Refreshed hero background treatment */
 .hero {
     position: relative;
     min-height: 100vh;
     display: flex;
     align-items: center;
-    background: url('https://images.unsplash.com/photo-1588072432836-e10032774350?auto=format&fit=crop&w=1600&q=80') center/cover no-repeat;
+    padding-top: 6.5rem;
+    background: url('https://images.unsplash.com/photo-1588072432836-e10032774350?auto=format&fit=crop&w=1600&q=80&fm=webp') center/cover no-repeat;
     color: #ffffff;
-    padding-top: 5rem;
 }
 
 .hero-overlay {
     position: absolute;
     inset: 0;
-    background: linear-gradient(120deg, rgba(68, 84, 106, 0.88), rgba(68, 114, 196, 0.68));
+    background: linear-gradient(120deg, rgba(26, 29, 87, 0.55), rgba(18, 93, 151, 0.35));
 }
 
 .hero .container {
     position: relative;
-    z-index: 2;
+    z-index: 1;
 }
 
-.glass-card {
-    background: rgba(255, 255, 255, 0.12);
-    border-radius: 24px;
-    border: 1px solid rgba(255, 255, 255, 0.25);
-    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.15);
-    color: #ffffff;
-    backdrop-filter: blur(12px);
+.bg-highlight {
+    background-color: rgba(109, 185, 87, 0.22) !important;
+    color: #ffffff !important;
+    letter-spacing: 0.08em;
 }
 
-.glass-card .btn-outline-primary {
+.hero-content {
+    max-width: 560px;
+    gap: 1rem;
+}
+
+.hero-copy-panel {
+    /* change: Added translucent dark panel to enhance hero text legibility */
+    backdrop-filter: blur(16px);
+    background: rgba(15, 24, 54, 0.58);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: var(--brand-radius-lg);
+    padding: clamp(1.5rem, 4vw, 2.25rem);
+    box-shadow: var(--brand-shadow-card);
+}
+
+.hero-content .lead {
+    color: #f4f6fb;
+    font-weight: 500;
+}
+
+.hero-cta-group {
+    margin-top: 1.5rem;
+}
+
+.hero-cta-group .btn-outline-secondary {
     color: #ffffff;
+    border-color: rgba(109, 185, 87, 0.9);
+    background-color: rgba(34, 155, 131, 0.28);
+}
+
+.hero-cta-group .btn-outline-secondary:hover {
+    background-color: var(--brand-green-500);
+    border-color: var(--brand-green-500);
+}
+
+.hero-card {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 2rem;
+}
+
+.hero-info-card {
+    backdrop-filter: blur(18px);
+    background: rgba(15, 24, 54, 0.65);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: var(--brand-radius-lg);
+    box-shadow: var(--brand-shadow-card-strong);
+    max-width: 420px;
+    color: #ffffff;
+}
+
+.hero-info-card h2 {
+    color: #ffffff;
+}
+
+.hero-info-card p,
+.hero-info-card li {
+    color: #dbe5ff;
+}
+
+.hero-info-card ul li {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.hero-info-card .btn-outline-primary {
     border-color: rgba(255, 255, 255, 0.6);
+    color: #ffffff;
 }
 
-.glass-card .btn-outline-primary:hover {
+.hero-info-card .btn-outline-primary:hover {
     background-color: #ffffff;
-    color: var(--primary-dark);
+    color: var(--brand-blue-600);
+    border-color: #ffffff;
 }
 
-.section-padding {
-    padding: 6rem 0;
-}
-
+/* change: Unified section headers */
 .section-badge {
     display: inline-block;
     font-size: 0.9rem;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--primary);
-    background-color: rgba(68, 114, 196, 0.08);
+    color: var(--brand-blue-600);
+    background-color: rgba(18, 93, 151, 0.1);
     padding: 0.35rem 1rem;
-    border-radius: 999px;
+    border-radius: var(--brand-radius-pill);
     font-weight: 600;
 }
 
 .section-title {
     margin-top: 1rem;
     margin-bottom: 0.75rem;
-    font-weight: 600;
 }
 
 .section-subtitle {
-    max-width: 600px;
+    max-width: 640px;
     margin: 0 auto;
 }
 
+/* change: Aligned product cards with consistent elevation */
 .product-card {
     border: none;
-    border-radius: 24px;
-    box-shadow: 0 24px 45px rgba(23, 35, 79, 0.08);
+    border-radius: var(--brand-radius-lg);
+    box-shadow: var(--brand-shadow-card);
     overflow: hidden;
-    transition: transform 0.4s ease, box-shadow 0.4s ease;
+    display: flex;
+    flex-direction: column;
+    background-color: #ffffff;
+    transition: transform var(--brand-transition), box-shadow var(--brand-transition);
+}
+
+.product-card picture,
+.product-card img {
+    display: block;
+    width: 100%;
 }
 
 .product-card img {
@@ -197,26 +387,105 @@ p {
 }
 
 .product-card:hover {
-    transform: translateY(-10px);
-    box-shadow: 0 30px 60px rgba(17, 32, 74, 0.15);
+    transform: translateY(-8px);
+    box-shadow: var(--brand-shadow-card-strong);
+}
+
+.product-card .card-body {
+    padding: 1.5rem;
 }
 
 .product-card .btn {
-    border-radius: 999px;
-    font-weight: 500;
+    border-radius: var(--brand-radius-pill);
 }
 
-.value-card {
+/* change: Standardized value and mission cards */
+.value-card,
+.mission-card {
     background: #ffffff;
-    border-radius: 20px;
+    border-radius: var(--brand-radius-lg);
     padding: 1.5rem;
-    box-shadow: 0 18px 40px rgba(21, 33, 76, 0.08);
-    transition: transform 0.3s ease;
+    box-shadow: var(--brand-shadow-card);
     height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
 }
 
-.value-card:hover {
+.mission-card {
+    padding: 2.5rem;
+}
+
+.mission-card ul {
+    padding-left: 0;
+    list-style: none;
+    margin: 0;
+}
+
+.mission-card ul li {
+    margin-bottom: 0.75rem;
+    color: var(--brand-gray-600);
+    display: flex;
+    gap: 0.5rem;
+}
+
+.partners-section {
+    /* change: Styled collaboration area with subtle gradient background */
+    background: linear-gradient(135deg, rgba(34, 155, 131, 0.06), rgba(18, 93, 151, 0.04));
+}
+
+.partner-card {
+    /* change: Crafted partner callout card to align with global card system */
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 2rem;
+    border-radius: var(--brand-radius-lg);
+    background-color: #ffffff;
+    box-shadow: var(--brand-shadow-card);
+    transition: transform var(--brand-transition), box-shadow var(--brand-transition);
+}
+
+.partner-card:hover {
     transform: translateY(-6px);
+    box-shadow: var(--brand-shadow-card-strong);
+}
+
+.partner-logo {
+    /* change: Ensured logo container keeps consistent sizing */
+    flex: 0 0 128px;
+    width: 128px;
+    height: 128px;
+}
+
+.partner-logo svg {
+    width: 100%;
+    height: 100%;
+    border-radius: 32px;
+    box-shadow: 0 10px 20px rgba(16, 24, 40, 0.12);
+}
+
+.partner-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.partner-name {
+    font-weight: 600;
+    color: var(--brand-gray-900);
+    margin: 0;
+}
+
+.partner-link {
+    color: var(--brand-blue-600);
+    font-weight: 500;
+    margin: 0;
+}
+
+.partner-card:focus-visible {
+    outline: 3px solid var(--brand-green-400);
+    outline-offset: 4px;
 }
 
 .icon-circle {
@@ -225,80 +494,185 @@ p {
     border-radius: 50%;
     display: grid;
     place-items: center;
-    background: linear-gradient(135deg, rgba(255, 192, 0, 0.2), rgba(68, 114, 196, 0.25));
-    color: var(--primary);
+    background: linear-gradient(135deg, rgba(34, 155, 131, 0.2), rgba(18, 93, 151, 0.25));
+    color: var(--brand-blue-600);
     font-size: 1.5rem;
     margin-bottom: 1rem;
 }
 
-.mission-card {
-    background: linear-gradient(160deg, rgba(68, 84, 106, 0.1), rgba(68, 114, 196, 0.15));
-    border-radius: 28px;
-    padding: 3rem;
-    box-shadow: 0 35px 60px rgba(17, 32, 74, 0.12);
-}
-
-.mission-card ul li {
-    margin-bottom: 0.75rem;
-    color: var(--text-muted);
-}
-
-.carousel-item {
-    transition: transform 0.8s ease, opacity 0.8s ease;
-}
-
+/* change: Refined testimonial styling */
 .testimonial-card {
     max-width: 640px;
     background: #ffffff;
     padding: 3rem;
-    border-radius: 26px;
-    box-shadow: 0 35px 70px rgba(23, 35, 79, 0.12);
+    border-radius: var(--brand-radius-lg);
+    box-shadow: var(--brand-shadow-card-strong);
 }
 
 .testimonial-text {
     font-size: 1.25rem;
     font-weight: 500;
-    color: var(--primary-dark);
+    color: var(--brand-indigo-800);
 }
 
 .testimonial-author {
     margin-top: 1.5rem;
     font-weight: 600;
-    color: var(--primary);
+    color: var(--brand-blue-600);
+}
+
+/* change: Styled founders section cards to align with product visuals */
+.creators-section {
+    background: radial-gradient(circle at top left, rgba(34, 155, 131, 0.08), transparent 55%);
+}
+
+.founder-card {
+    background: #ffffff;
+    border-radius: var(--brand-radius-lg);
+    box-shadow: var(--brand-shadow-card);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    height: 100%;
+    transition: transform var(--brand-transition), box-shadow var(--brand-transition);
+}
+
+.founder-card:hover {
+    transform: translateY(-6px);
+    box-shadow: var(--brand-shadow-card-strong);
+}
+
+.founder-photo {
+    display: block;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    overflow: hidden;
+}
+
+.founder-photo img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.founder-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1.75rem;
+}
+
+.founder-name {
+    font-weight: 700;
+    margin-bottom: 0;
+}
+
+.founder-role {
+    color: var(--brand-gray-600);
+    font-weight: 500;
+}
+
+.founder-bio {
+    flex: 1;
+}
+
+.founder-card .btn {
+    align-self: flex-start;
 }
 
 .testimonial-role {
-    color: var(--text-muted);
+    color: var(--brand-gray-600);
 }
 
+/* change: Softened contact section background */
 .contact-section {
-    background: linear-gradient(120deg, rgba(245, 247, 251, 0.95), rgba(236, 242, 255, 0.95));
+    background: linear-gradient(120deg, rgba(242, 244, 247, 0.95), rgba(220, 236, 244, 0.9));
 }
 
 .contact-info {
     display: grid;
-    gap: 1.5rem;
+    gap: 1.75rem;
     margin-top: 2rem;
 }
 
 .contact-info i {
     font-size: 1.5rem;
-    color: var(--primary);
+    color: var(--brand-blue-600);
 }
 
+.team-links {
+    display: grid;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.team-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--brand-blue-600);
+    font-weight: 500;
+}
+
+.team-link i {
+    font-size: 1.1rem;
+}
+
+.team-link:hover {
+    color: var(--brand-blue-700);
+}
+
+.team-link:focus-visible {
+    outline: 2px solid var(--brand-green-500);
+    outline-offset: 2px;
+}
+
+/* change: Added accessible form states */
 .contact-form .form-control {
     border-radius: 14px;
-    border: 1px solid rgba(68, 114, 196, 0.2);
+    border: 1px solid rgba(16, 24, 40, 0.12);
     padding: 0.75rem 1rem;
+    color: var(--brand-gray-900);
 }
 
 .contact-form .form-control:focus {
-    border-color: var(--primary);
-    box-shadow: 0 0 0 0.25rem rgba(68, 114, 196, 0.15);
+    border-color: var(--brand-blue-600);
+    box-shadow: 0 0 0 0.25rem rgba(18, 93, 151, 0.15);
 }
 
+/* change: Styled accessible form helper and error messaging */
+.form-hint {
+    font-size: 0.85rem;
+    color: var(--brand-gray-600);
+    margin-top: 0.4rem;
+    margin-bottom: 0.2rem;
+}
+
+.form-error {
+    font-size: 0.85rem;
+    color: var(--brand-blue-700);
+    min-height: 1em;
+    margin-top: 0.25rem;
+    display: none;
+}
+
+.form-error.is-visible {
+    display: block;
+}
+
+.form-status {
+    font-weight: 500;
+    color: var(--brand-green-500);
+    min-height: 1.25rem;
+}
+
+.form-status.is-error {
+    color: var(--brand-blue-700);
+}
+
+/* change: Styled footer with brand indigo */
 .footer {
-    background: #0f172a;
+    background: var(--brand-indigo-800);
     color: rgba(255, 255, 255, 0.85);
 }
 
@@ -314,30 +688,30 @@ p {
 
 .footer-links a {
     color: rgba(255, 255, 255, 0.75);
-    text-decoration: none;
-    transition: color 0.3s ease;
+    transition: color var(--brand-transition);
 }
 
 .footer-links a:hover {
-    color: var(--secondary);
+    color: var(--brand-green-400);
 }
 
 .social-links a {
     color: rgba(255, 255, 255, 0.75);
     font-size: 1.3rem;
     margin-left: 0.75rem;
-    transition: color 0.3s ease, transform 0.3s ease;
+    transition: color var(--brand-transition), transform var(--brand-transition);
 }
 
 .social-links a:hover {
-    color: var(--secondary);
+    color: var(--brand-green-400);
     transform: translateY(-3px);
 }
 
+/* change: Animated reveal utility */
 [data-animate] {
     opacity: 0;
     transform: translateY(35px);
-    transition: opacity 0.8s ease, transform 0.8s ease;
+    transition: opacity 500ms ease, transform 500ms ease;
 }
 
 [data-animate].animated {
@@ -345,31 +719,70 @@ p {
     transform: translateY(0);
 }
 
-@media (max-width: 991.98px) {
+/* change: Responsive adjustments */
+@media (max-width: 1024px) {
     .hero {
         padding-top: 7rem;
-        text-align: center;
-    }
-
-    .hero-card {
-        margin-top: 3rem;
     }
 
     .mission-card {
-        padding: 2.5rem;
+        padding: 2rem;
     }
 }
 
-@media (max-width: 575.98px) {
+@media (max-width: 640px) {
     .hero {
+        text-align: center;
         min-height: 90vh;
     }
 
-    .glass-card {
-        padding: 2.5rem 1.75rem;
+    .hero-card {
+        justify-content: center;
+        margin-top: 2.5rem;
+    }
+
+    .hero-info-card {
+        max-width: min(420px, 100%);
     }
 
     .testimonial-card {
         padding: 2.25rem 1.75rem;
+    }
+
+    .language-switcher {
+        margin-top: 1rem;
+    }
+
+    .partner-card {
+        /* change: Stack partner card content on small screens */
+        flex-direction: column;
+        text-align: center;
+        align-items: center;
+    }
+
+    .partner-copy {
+        align-items: center;
+        text-align: center;
+    }
+
+    .partner-logo {
+        width: 104px;
+        height: 104px;
+    }
+}
+
+@media (min-width: 641px) and (max-width: 1024px) {
+    .hero-card {
+        margin-top: 3rem;
+    }
+}
+
+/* change: Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+    * {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
     }
 }


### PR DESCRIPTION
## Summary
- wrap the hero headline and subtitle in a translucent panel to lift contrast against the background imagery
- introduce a reusable hero-copy-panel style that mirrors the bioreactor card treatment while preserving brand tokens

## Testing
- not run (static site changes only)

------
https://chatgpt.com/codex/tasks/task_e_68dd9dcde5b08321ad2a2da12f0b1ee0